### PR TITLE
fix cifar transforms

### DIFF
--- a/datasets/seq_cifar10.py
+++ b/datasets/seq_cifar10.py
@@ -21,15 +21,12 @@ from datasets.mammoth_dataset import MammothDataset
 
 
 class TrainCIFAR10(MammothDataset, CIFAR10):
-    def __init__(self, root: str, train: bool = True, transform=None, target_transform=None,
-                 not_aug_transform=None, drift_transform=None,
-                 download: bool = False) -> None:
-        super().__init__(root, train, transform, target_transform, download)
+    def __init__(self, root: str, transform, not_aug_transform, train_drift, drift_transform,
+                 ) -> None:
+        super().__init__(root, train=True, transform=transform, target_transform=None, download=True)
         self.not_aug_transform = not_aug_transform
+        self.train_drift = train_drift
         self.drift_transform = drift_transform
-        assert transform is not None  # TODO fix parameter order
-        assert not_aug_transform is not None
-        assert drift_transform is not None
         self.classes = list(range(10))
 
     def __getitem__(self, index: int) -> Tuple[Image.Image, int, Image.Image]:
@@ -42,17 +39,15 @@ class TrainCIFAR10(MammothDataset, CIFAR10):
 
         # to return a PIL Image
         img = Image.fromarray(img, mode='RGB')
-        original_img = img.copy()
 
         if target in self.drifted_classes:
             img = self.drift_transform(img)
-            not_aug_img = self.drift_transform(original_img)
         else:
-            img = self.transform(img)
-            not_aug_img = self.not_aug_transform(original_img)
+            img = self.train_drift(img)
 
-        if self.target_transform is not None:
-            target = self.target_transform(target)
+        original_img = img.copy()
+        img = self.transform(img)
+        not_aug_img = self.not_aug_transform(original_img)
 
         if hasattr(self, 'logits'):
             return img, target, not_aug_img, self.logits[index]
@@ -89,12 +84,11 @@ class TrainCIFAR10(MammothDataset, CIFAR10):
 class TestCIFAR10(MammothDataset, CIFAR10):
     """Workaround to avoid printing the already downloaded messages."""
 
-    def __init__(self, root, train=True, transform=None, drift_transform=None, target_transform=None, download=False) -> None:
+    def __init__(self, root, transform, train_drift, drift_transform) -> None:
         self.root = root
-        super().__init__(root, train, transform, target_transform, download=not self._check_integrity())
+        super().__init__(root, train=False, transform=transform, target_transform=None, download=not self._check_integrity())
+        self.train_drift = train_drift
         self.drift_transform = drift_transform
-        assert transform is not None  # TODO fix parameter order
-        assert drift_transform is not None
 
         self.classes = list(range(10))
 
@@ -115,10 +109,9 @@ class TestCIFAR10(MammothDataset, CIFAR10):
         if target in self.drifted_classes:
             img = self.drift_transform(img)
         else:
-            img = self.transform(img)
+            img = self.train_drift(img)
 
-        if self.target_transform is not None:
-            target = self.target_transform(target)
+        img = self.transform(img)
 
         return img, target
 
@@ -153,6 +146,12 @@ class SequentialCIFAR10(ContinualDataset):
     N_CLASSES_PER_TASK = 2
     N_TASKS = 5
 
+    TRANSFORM = transforms.Compose([
+        transforms.RandomCrop(32, padding=4),
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+    ])
+
     DRIFT_TYPES = [
         DefocusBlur,
         GaussianNoise,
@@ -164,51 +163,28 @@ class SequentialCIFAR10(ContinualDataset):
     def get_dataset(self, train=True):
         """returns native version of represented dataset"""
         DRIFT_SEVERITY = self.args.drift_severity
-        TRAIN_DRIFT = self.DRIFT_TYPES[self.args.train_drift]
-        DRIFT = self.DRIFT_TYPES[self.args.concept_drift]
-        TRANSFORM = transforms.Compose([
-            TRAIN_DRIFT(DRIFT_SEVERITY),
-            transforms.ToPILImage(),
-            transforms.RandomCrop(32, padding=4),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
+        TRAIN_DRIFT = transforms.Compose([
+            self.DRIFT_TYPES[self.args.train_drift](DRIFT_SEVERITY),
+            transforms.ToPILImage()
         ])
-        TEST_TRANSFORM = transforms.Compose([
-            TRAIN_DRIFT(DRIFT_SEVERITY),
-            transforms.ToPILImage(),
+        DRIFT = transforms.Compose([
+            self.DRIFT_TYPES[self.args.concept_drift](DRIFT_SEVERITY),
+            transforms.ToPILImage()
+        ])
+
+        NO_AUG = transforms.Compose([
             transforms.ToTensor(),
         ])
         if train:
-            DRIFT_TRANSFORM = transforms.Compose([
-                DRIFT(DRIFT_SEVERITY),
-                transforms.ToPILImage(),
-                transforms.RandomCrop(32, padding=4),
-                transforms.RandomHorizontalFlip(),
-                transforms.ToTensor(),
-            ])
-            return TrainCIFAR10(base_path() + 'CIFAR10', train=True, download=True, transform=TRANSFORM,
-                                not_aug_transform=transforms.Compose([transforms.ToTensor()]), drift_transform=DRIFT_TRANSFORM)
+            return TrainCIFAR10(base_path() + 'CIFAR10',
+                                transform=self.TRANSFORM, not_aug_transform=NO_AUG, train_drift=TRAIN_DRIFT, drift_transform=DRIFT)
         else:
-            DRIFT_TRANSFORM = transforms.Compose([
-                DRIFT(DRIFT_SEVERITY),
-                transforms.ToPILImage(),
-                transforms.ToTensor(),
-            ])
-            return TestCIFAR10(base_path() + 'CIFAR10', train=False, download=True, transform=TEST_TRANSFORM,
-                               drift_transform=DRIFT_TRANSFORM)
+            return TestCIFAR10(base_path() + 'CIFAR10',
+                               transform=NO_AUG, train_drift=TRAIN_DRIFT, drift_transform=DRIFT)
 
     def get_transform(self):
-        DRIFT_SEVERITY = self.args.drift_severity
-        DRIFT = self.DRIFT_TYPES[self.args.train_drift]
-        TRANSFORM = transforms.Compose([
-            DRIFT(DRIFT_SEVERITY),
-            transforms.ToPILImage(),
-            transforms.RandomCrop(32, padding=4),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
-        ])
         transform = transforms.Compose(
-            [transforms.ToPILImage(), TRANSFORM])
+            [transforms.ToPILImage(), self.TRANSFORM])
         return transform
 
     @staticmethod

--- a/datasets/seq_cifar100.py
+++ b/datasets/seq_cifar100.py
@@ -21,15 +21,11 @@ from datasets.mammoth_dataset import MammothDataset
 
 
 class TrainCIFAR100(MammothDataset, CIFAR100):
-    def __init__(self, root: str, train: bool = True, transform=None, target_transform=None,
-                 not_aug_transform=None, drift_transform=None,
-                 download: bool = False) -> None:
-        super().__init__(root, train, transform, target_transform, download)
+    def __init__(self, root: str, transform, not_aug_transform, train_drift, drift_transform) -> None:
+        super().__init__(root, train=True, transform=transform, target_transform=None, download=True)
         self.not_aug_transform = not_aug_transform
+        self.train_drift = train_drift
         self.drift_transform = drift_transform
-        assert transform is not None  # TODO fix parameter order
-        assert not_aug_transform is not None
-        assert drift_transform is not None
         self.classes = list(range(100))
 
     def __getitem__(self, index: int) -> Tuple[Image.Image, int, Image.Image]:
@@ -42,17 +38,15 @@ class TrainCIFAR100(MammothDataset, CIFAR100):
 
         # to return a PIL Image
         img = Image.fromarray(img, mode='RGB')
-        original_img = img.copy()
 
         if target in self.drifted_classes:
             img = self.drift_transform(img)
-            not_aug_img = self.drift_transform(original_img)
         else:
-            img = self.transform(img)
-            not_aug_img = self.not_aug_transform(original_img)
+            img = self.train_drift(img)
 
-        if self.target_transform is not None:
-            target = self.target_transform(target)
+        original_img = img.copy()
+        img = self.transform(img)
+        not_aug_img = self.not_aug_transform(original_img)
 
         if hasattr(self, 'logits'):
             return img, target, not_aug_img, self.logits[index]
@@ -89,12 +83,11 @@ class TrainCIFAR100(MammothDataset, CIFAR100):
 class TestCIFAR100(MammothDataset, CIFAR100):
     """Workaround to avoid printing the already downloaded messages."""
 
-    def __init__(self, root, train=True, transform=None, drift_transform=None, target_transform=None, download=False) -> None:
+    def __init__(self, root, transform, train_drift, drift_transform) -> None:
         self.root = root
-        super().__init__(root, train, transform, target_transform, download=not self._check_integrity())
+        super().__init__(root, train=False, transform=transform, target_transform=None, download=not self._check_integrity())
+        self.train_drift = train_drift
         self.drift_transform = drift_transform
-        assert transform is not None  # TODO fix parameter order
-        assert drift_transform is not None
 
         self.classes = list(range(100))
 
@@ -115,10 +108,9 @@ class TestCIFAR100(MammothDataset, CIFAR100):
         if target in self.drifted_classes:
             img = self.drift_transform(img)
         else:
-            img = self.transform(img)
+            img = self.train_drift(img)
 
-        if self.target_transform is not None:
-            target = self.target_transform(target)
+        img = self.transform(img)
 
         return img, target
 
@@ -153,6 +145,12 @@ class SequentialCIFAR100(ContinualDataset):
     N_CLASSES_PER_TASK = 5
     N_TASKS = 20
 
+    TRANSFORM = transforms.Compose([
+        transforms.RandomCrop(32, padding=4),
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+    ])
+
     DRIFT_TYPES = [
         DefocusBlur,
         GaussianNoise,
@@ -164,51 +162,28 @@ class SequentialCIFAR100(ContinualDataset):
     def get_dataset(self, train=True):
         """returns native version of represented dataset"""
         DRIFT_SEVERITY = self.args.drift_severity
-        TRAIN_DRIFT = self.DRIFT_TYPES[self.args.train_drift]
-        DRIFT = self.DRIFT_TYPES[self.args.concept_drift]
-        TRANSFORM = transforms.Compose([
-            TRAIN_DRIFT(DRIFT_SEVERITY),
-            transforms.ToPILImage(),
-            transforms.RandomCrop(32, padding=4),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
+        TRAIN_DRIFT = transforms.Compose([
+            self.DRIFT_TYPES[self.args.train_drift](DRIFT_SEVERITY),
+            transforms.ToPILImage()
         ])
-        TEST_TRANSFORM = transforms.Compose([
-            TRAIN_DRIFT(DRIFT_SEVERITY),
-            transforms.ToPILImage(),
+        DRIFT = transforms.Compose([
+            self.DRIFT_TYPES[self.args.concept_drift](DRIFT_SEVERITY),
+            transforms.ToPILImage()
+        ])
+
+        NO_AUG = transforms.Compose([
             transforms.ToTensor(),
         ])
         if train:
-            DRIFT_TRANSFORM = transforms.Compose([
-                DRIFT(DRIFT_SEVERITY),
-                transforms.ToPILImage(),
-                transforms.RandomCrop(32, padding=4),
-                transforms.RandomHorizontalFlip(),
-                transforms.ToTensor(),
-            ])
-            return TrainCIFAR100(base_path() + 'CIFAR100', train=True, download=True, transform=TRANSFORM,
-                                 not_aug_transform=transforms.Compose([transforms.ToTensor()]), drift_transform=DRIFT_TRANSFORM)
+            return TrainCIFAR100(base_path() + 'CIFAR100',
+                                 transform=self.TRANSFORM, not_aug_transform=NO_AUG, train_drift=TRAIN_DRIFT, drift_transform=DRIFT)
         else:
-            DRIFT_TRANSFORM = transforms.Compose([
-                DRIFT(DRIFT_SEVERITY),
-                transforms.ToPILImage(),
-                transforms.ToTensor(),
-            ])
-            return TestCIFAR100(base_path() + 'CIFAR100', train=False, download=True, transform=TEST_TRANSFORM,
-                                drift_transform=DRIFT_TRANSFORM)
+            return TestCIFAR100(base_path() + 'CIFAR100',
+                                transform=NO_AUG, train_drift=TRAIN_DRIFT, drift_transform=DRIFT)
 
     def get_transform(self):
-        DRIFT_SEVERITY = self.args.drift_severity
-        DRIFT = self.DRIFT_TYPES[self.args.train_drift]
-        TRANSFORM = transforms.Compose([
-            DRIFT(DRIFT_SEVERITY),
-            transforms.ToPILImage(),
-            transforms.RandomCrop(32, padding=4),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
-        ])
         transform = transforms.Compose(
-            [transforms.ToPILImage(), TRANSFORM])
+            [transforms.ToPILImage(), self.TRANSFORM])
         return transform
 
     @staticmethod


### PR DESCRIPTION
I found an error in the cifar datasets. Drift transforms were applied twice for data that was stored in the buffer. The first time was when applying drift_transform in the training dataset. Second, the train_drift was applied during sampling from the buffer (it is in the transforms list in the get_transforms method). Another consequence is that transforms like random crop or random flip were applied twice.

I've separated the drift transforms from image transforms. Now proper drift transforms (concept drifts or train drift) are applied in the first step, and later, we apply image transforms (like random crop or random flip). To avoid having too many constructor arguments, I've removed some of those that didn't make sense (for example, there is no point in passing train=True to TrainCIFAR100).