### PR TITLE
Meta-class and fine-grained class in buffer for label drift detection

### DIFF
--- a/datasets/seq_cifar100_label_drift.py
+++ b/datasets/seq_cifar100_label_drift.py
@@ -151,7 +151,6 @@ class SequentialCIFAR100LabelDrift(ContinualDataset):
     N_CLASSES_PER_TASK = 5
     N_TASKS = 20
     HAS_LABEL_DRIFT = True
-    METACLASSES = [0, 1]
 
     TRANSFORM = transforms.Compose(
         [
@@ -188,8 +187,7 @@ class SequentialCIFAR100LabelDrift(ContinualDataset):
 
     @staticmethod
     def get_backbone():
-        backbone = resnet18(nclasses=2)
-        return backbone
+        return resnet18(nclasses=2)
 
     @staticmethod
     def get_loss():

--- a/datasets/seq_fashionmnist.py
+++ b/datasets/seq_fashionmnist.py
@@ -128,10 +128,8 @@ class SequentialFashionMNIST(ContinualDataset):
     N_CLASSES_PER_TASK = 2
     N_TASKS = 5
     HAS_LABEL_DRIFT = True
-    METACLASSES = [0, 1]
 
     TRANSFORM = transforms.Compose([
-        # transforms.ToPILImage(),
         transforms.Resize(32),
         transforms.RandomCrop(32, padding=4),
         transforms.RandomHorizontalFlip(),

--- a/models/er.py
+++ b/models/er.py
@@ -27,14 +27,18 @@ class Er(ContinualModel):
         super(Er, self).__init__(backbone, loss, args, transform)
         self.buffer = Buffer(self.args.buffer_size, self.device)
 
-    def observe(self, inputs, labels, not_aug_inputs):
+    def observe(self, inputs, labels, not_aug_inputs, original_targets=None):
 
         real_batch_size = inputs.shape[0]
 
         self.opt.zero_grad()
         if not self.buffer.is_empty():
-            buf_inputs, buf_labels = self.buffer.get_data(
-                self.args.minibatch_size, transform=self.transform)
+            if original_targets is not None:
+                buf_inputs, buf_labels, _ = self.buffer.get_data(
+                    self.args.minibatch_size, transform=self.transform)
+            else:
+                buf_inputs, buf_labels = self.buffer.get_data(
+                    self.args.minibatch_size, transform=self.transform)
             inputs = torch.cat((inputs, buf_inputs))
             labels = torch.cat((labels, buf_labels))
 
@@ -43,7 +47,12 @@ class Er(ContinualModel):
         loss.backward()
         self.opt.step()
 
-        self.buffer.add_data(examples=not_aug_inputs,
+        if original_targets is not None:
+            self.buffer.add_data(examples=not_aug_inputs,
+                             labels=labels[:real_batch_size],
+                             original_labels=original_targets[:real_batch_size])
+        else: 
+            self.buffer.add_data(examples=not_aug_inputs,
                              labels=labels[:real_batch_size])
 
         return loss.item()

--- a/utils/buffer.py
+++ b/utils/buffer.py
@@ -258,17 +258,17 @@ class Buffer:
         self.num_seen_examples = 0
         self.current_size = 0
 
-    def get_class_data(self, label: int, metaclass: bool = False) -> torch.Tensor:
+    def get_class_data(self, label: int, labeldrift: bool = False) -> torch.Tensor:
         """
         Return all samples with given label.
         If label not present in the buffer, then raise ValueError exception.
         """
-        if metaclass:
+        if labeldrift:
             idx = torch.argwhere(self.original_labels == label).flatten()
         else:
             idx = torch.argwhere(self.labels == label).flatten()
         if len(idx) == 0:
-            print(f'{"Metaclass" if metaclass else "Class"} label {label} not present in the buffer')
+            print(f'{"Metaclass" if labeldrift else "Class"} label {label} not present in the buffer')
             return 0
         class_samples = self.examples[idx]
         return class_samples
@@ -283,19 +283,19 @@ class Buffer:
         else:
             return 0
 
-    def flush_class(self, label: int, metaclass: bool = False) -> None:
+    def flush_class(self, label: int, labeldrift: bool = False) -> None:
         """
         Removes all samples with given label.
         If label not present in the buffer, then raise ValueError exception.
         """
-        if metaclass:
+        if labeldrift:
             idx = torch.argwhere(self.original_labels != label).flatten()
             num_removed = len(self.original_labels) - len(idx)
         else:
             idx = torch.argwhere(self.labels != label).flatten()
             num_removed = len(self.labels) - len(idx)
         if num_removed == 0:
-            raise ValueError(f'{"Metaclass" if metaclass else "Class"} label {label} not present in the buffer')
+            raise ValueError(f'{"Metaclass" if labeldrift else "Class"} label {label} not present in the buffer')
         for attr_str in self.attributes:
             if hasattr(self, attr_str):
                 tensor = getattr(self, attr_str)
@@ -306,4 +306,4 @@ class Buffer:
                 setattr(self, attr_str, new_tensor)
         self.current_size = max(self.current_size - num_removed, 0)
         self.num_seen_examples -= num_removed
-        print(f'{"Metaclass" if metaclass else "Class"} {label} samples removed: {num_removed}')
+        print(f'{"Metaclass" if labeldrift else "Class"} {label} samples removed: {num_removed}')

--- a/utils/drift_detection.py
+++ b/utils/drift_detection.py
@@ -10,19 +10,31 @@ from alibi_detect.cd import MMDDrift, ClassifierUncertaintyDrift
 
 def initialize_detector(ref_data, device):
     encoding_dim = 32
-    encoder_net = nn.Sequential(
-        nn.Conv2d(3, 64, 4, stride=2, padding=0),
-        nn.ReLU(),
-        nn.Conv2d(64, 128, 4, stride=2, padding=0),
-        nn.ReLU(),
-        nn.Conv2d(128, 512, 4, stride=2, padding=0),
-        nn.ReLU(),
-        nn.Flatten(),
-        nn.Linear(2048, encoding_dim)
-    ).to(device).eval()
+    encoder_net = (
+        nn.Sequential(
+            nn.Conv2d(3, 64, 4, stride=2, padding=0),
+            nn.ReLU(),
+            nn.Conv2d(64, 128, 4, stride=2, padding=0),
+            nn.ReLU(),
+            nn.Conv2d(128, 512, 4, stride=2, padding=0),
+            nn.ReLU(),
+            nn.Flatten(),
+            nn.Linear(2048, encoding_dim),
+        )
+        .to(device)
+        .eval()
+    )
 
-    preprocess_fn = partial(preprocess_drift, model=encoder_net, device=device, batch_size=512)
-    cd = MMDDrift(ref_data, backend='pytorch', p_val=.05, preprocess_fn=preprocess_fn, n_permutations=100)
+    preprocess_fn = partial(
+        preprocess_drift, model=encoder_net, device=device, batch_size=512
+    )
+    cd = MMDDrift(
+        ref_data,
+        backend="pytorch",
+        p_val=0.05,
+        preprocess_fn=preprocess_fn,
+        n_permutations=100,
+    )
 
     return cd
 
@@ -31,7 +43,7 @@ def detect_drift(drifting_classes, train_loader, model):
     if len(drifting_classes) == 0:
         return
 
-    labels = ['No!', 'Yes!']
+    labels = ["No!", "Yes!"]
 
     for cls in drifting_classes:
         filtered_images = []
@@ -46,7 +58,7 @@ def detect_drift(drifting_classes, train_loader, model):
             ref_samples = model.buffer.get_class_data(cls)
             drift_detector = initialize_detector(ref_samples, model.device)
             preds = drift_detector.predict(new_images)
-            print('')
+            print("")
             print(f"Drift in class {cls}? {labels[preds['data']['is_drift']]}")
             print(f'p-value: {preds["data"]["p_val"]:.3f}')
             print(f'MMD-Distance: {preds["data"]["distance"]:.3f}')
@@ -60,7 +72,9 @@ def initialize_uncertainty_detector(ref_data, device):
     num_features = clf.fc.in_features
     clf.fc = nn.Linear(num_features, encoding_dim)
     clf = clf.to(device).eval()
-    cd = ClassifierUncertaintyDrift(ref_data, model=clf, backend='pytorch', p_val=0.05, preds_type='logits')
+    cd = ClassifierUncertaintyDrift(
+        ref_data, model=clf, backend="pytorch", p_val=0.05, preds_type="logits"
+    )
 
     return cd
 
@@ -70,51 +84,28 @@ def detect_uncertainty_drift(dataset, train_loader, model):
     if len(drifting_classes) == 0:
         return
 
-    labels = ['No!', 'Yes!']
+    labels = ["No!", "Yes!"]
 
     for cls in drifting_classes:
         filtered_images = []
-        for img_batch, target_batch, _ in train_loader:
+        for batch in train_loader:
+            img_batch, target_batch = batch[0], batch[1]
             mask = target_batch == cls
+            if dataset.HAS_LABEL_DRIFT:
+                original_target_batch = batch[-1]
+                mask = original_target_batch == cls
             selected_images = img_batch[mask]
             filtered_images.append(selected_images)
 
         new_images = torch.cat(filtered_images, dim=0)
 
-        if new_images.size(0) > 0 and hasattr(model, 'buffer'):
-            ref_samples = model.buffer.get_class_data(cls)
+        if new_images.size(0) > 0 and hasattr(model, "buffer"):
+            ref_samples = model.buffer.get_class_data(cls, labeldrift=dataset.HAS_LABEL_DRIFT)
             if not isinstance(ref_samples, int):
                 drift_detector = initialize_uncertainty_detector(ref_samples, model.device)
                 preds = drift_detector.predict(new_images)
                 print(f"Drift in class {cls}? {labels[preds['data']['is_drift']]}")
                 print(f"Feature-wise p-values: {', '.join([f'{p_val:.3f}' for p_val in preds['data']['p_val']])}")
 
-                if preds['data']['is_drift']:       # removing drifted samples from buffer
-                    model.buffer.flush_class(cls)
-
-def detect_uncertainty_label_drift(dataset, train_loader, model):
-    drifting_classes = dataset.drifting_classes
-    if len(drifting_classes) == 0:
-        return
-        
-    labels = ['No!', 'Yes!']
-
-    for cls in drifting_classes:
-        filtered_images = []
-        for img_batch, _, _, original_target_batch in train_loader:
-            mask = original_target_batch == cls
-            selected_images = img_batch[mask]
-            filtered_images.append(selected_images)
-
-        new_images = torch.cat(filtered_images, dim=0)
-
-        if new_images.size(0) > 0 and hasattr(model, 'buffer'):
-            ref_samples = model.buffer.get_class_data(cls, metaclass=True)
-            if not isinstance(ref_samples, int):
-                drift_detector = initialize_uncertainty_detector(ref_samples, model.device)
-                preds = drift_detector.predict(new_images)
-                print(f"Drift in metaclass {cls}? {labels[preds['data']['is_drift']]}")
-                print(f"Feature-wise p-values: {', '.join([f'{p_val:.3f}' for p_val in preds['data']['p_val']])}")
-
-                if preds['data']['is_drift']:       # removing drifted samples from buffer
-                    model.buffer.flush_class(cls, metaclass=True)
+                if preds["data"]["is_drift"]:  # removing drifted samples from buffer
+                    model.buffer.flush_class(cls, labeldrift=dataset.HAS_LABEL_DRIFT)

--- a/utils/drift_detection.py
+++ b/utils/drift_detection.py
@@ -96,7 +96,7 @@ def detect_uncertainty_label_drift(dataset, train_loader, model):
     drifting_classes = dataset.drifting_classes
     if len(drifting_classes) == 0:
         return
-
+        
     labels = ['No!', 'Yes!']
 
     for cls in drifting_classes:
@@ -108,14 +108,13 @@ def detect_uncertainty_label_drift(dataset, train_loader, model):
 
         new_images = torch.cat(filtered_images, dim=0)
 
-    if new_images.size(0) > 0 and hasattr(model, 'buffer'):
-        for meta_cls in dataset.METACLASSES:
-            ref_samples = model.buffer.get_class_data(meta_cls)
+        if new_images.size(0) > 0 and hasattr(model, 'buffer'):
+            ref_samples = model.buffer.get_class_data(cls, metaclass=True)
             if not isinstance(ref_samples, int):
                 drift_detector = initialize_uncertainty_detector(ref_samples, model.device)
                 preds = drift_detector.predict(new_images)
-                print(f"Drift in class {meta_cls}? {labels[preds['data']['is_drift']]}")
+                print(f"Drift in metaclass {cls}? {labels[preds['data']['is_drift']]}")
                 print(f"Feature-wise p-values: {', '.join([f'{p_val:.3f}' for p_val in preds['data']['p_val']])}")
 
                 if preds['data']['is_drift']:       # removing drifted samples from buffer
-                    model.buffer.flush_class(meta_cls)
+                    model.buffer.flush_class(cls, metaclass=True)

--- a/utils/training.py
+++ b/utils/training.py
@@ -13,7 +13,7 @@ import torch
 from datasets import get_dataset
 from datasets.utils.continual_dataset import ContinualDataset
 from models.utils.continual_model import ContinualModel
-from drift_detection import detect_uncertainty_drift, detect_uncertainty_label_drift
+from drift_detection import detect_uncertainty_drift
 from utils.loggers import *
 from utils.status import ProgressBar
 
@@ -126,10 +126,7 @@ def train(model: ContinualModel, dataset: ContinualDataset, args: Namespace) -> 
             if dataset.SETTING == 'class-il':
                 results_mask_classes[t-1] = results_mask_classes[t-1] + accs[1]
         if args.buffer_flushing == 1:
-            if dataset.HAS_LABEL_DRIFT:
-                detect_uncertainty_label_drift(dataset, train_loader, model)
-            else:
-                detect_uncertainty_drift(dataset, train_loader, model)
+            detect_uncertainty_drift(dataset, train_loader, model)
         scheduler = dataset.get_scheduler(model, args)
         for epoch in range(model.args.n_epochs):
             if args.model == 'joint':
@@ -138,26 +135,22 @@ def train(model: ContinualModel, dataset: ContinualDataset, args: Namespace) -> 
                 if args.debug_mode and i > 3:
                     break
                 if hasattr(dataset.train_loader.dataset, 'logits'):
-                    inputs, labels, not_aug_inputs, logits = data[0], data[1], data[2], data[-1]
+                    inputs, labels, not_aug_inputs, original_targets, logits = data[0], data[1], data[2], None, data[-1]
                     inputs = inputs.to(model.device)
                     labels = labels.to(model.device)
                     not_aug_inputs = not_aug_inputs.to(model.device)
                     logits = logits.to(model.device)
                     if dataset.HAS_LABEL_DRIFT:
-                        original_targets = data[3]
-                        original_targets = original_targets.to(model.device)
-                        loss = model.meta_observe(inputs, labels, not_aug_inputs, logits, original_targets)
-                    else: loss = model.meta_observe(inputs, labels, not_aug_inputs, logits)
+                        original_targets = data[3].to(model.device)
+                    loss = model.meta_observe(inputs, labels, not_aug_inputs, logits, original_targets)
                 else:
-                    inputs, labels, not_aug_inputs = data[0], data[1], data[2]
+                    inputs, labels, not_aug_inputs, original_targets = data[0], data[1], data[2], None
                     inputs = inputs.to(model.device)
                     labels = labels.to(model.device)
                     not_aug_inputs = not_aug_inputs.to(model.device)
                     if dataset.HAS_LABEL_DRIFT:
-                        original_targets = data[3]
-                        original_targets = original_targets.to(model.device)
-                        loss = model.meta_observe(inputs, labels, not_aug_inputs, original_targets)
-                    else: loss = model.meta_observe(inputs, labels, not_aug_inputs)
+                        original_targets = data[3].to(model.device)
+                    loss = model.meta_observe(inputs, labels, not_aug_inputs, original_targets)
                 assert not math.isnan(loss)
                 progress_bar.prog(i, len(train_loader), epoch, t, loss)
 


### PR DESCRIPTION
This is a rough implementation of storing both the metaclass and fine-grained class in the buffer. This is not the final implementation. I created this branch just for code review, we don't have to merge it. After finishing the whole implementation, I realized it could be done in a much simpler and cleaner way if we simply return the fine-grained targets as before and just return the meta-labels as an additional parameter. That way, we can keep the rest of the code unchanged, and simply handle the metaclasses for the label drifting datasets. I will work on this refinement after our meeting tomorrow (11:00 am GMT-4). 