### PR TITLE
Domain incremental drift

### DIFF
--- a/datasets/seq_cifar100.py
+++ b/datasets/seq_cifar100.py
@@ -135,7 +135,6 @@ class TestCIFAR100(MammothDataset, CIFAR100):
         if len(set(self.classes).union(classes)) == 0:
             return
         self.drifted_classes.extend(classes)
-        print(f"All drifted classes: {self.drifted_classes}")
 
     def prepare_normal_data(self):
         pass

--- a/datasets/stream_spec.py
+++ b/datasets/stream_spec.py
@@ -10,7 +10,7 @@ class StreamSpecification:
         n_tasks: int,
         n_classes: int,
         random_seed: int = None,
-        n_slots: Union[int, None] = None,
+        # n_slots: Union[int, None] = None,     # For future implementations
         n_drifts: Union[int, None] = None,
         sequential_drifts: bool = False,
         max_classes_per_drift: int = 0,
@@ -28,17 +28,17 @@ class StreamSpecification:
         max_classes_per_drifts - number of classes that drift is applied to. used only with n_drifts
         """
         assert n_tasks >= 2, 'need at least two tasks for continual learning'
-        assert n_slots is not None or n_drifts is not None or sequential_drifts, 'must specify drift type'
+        assert n_drifts is not None or sequential_drifts, 'must specify drift type'
 
-        if n_slots is not None:
-            assert n_drifts == None and sequential_drifts == False, 'you must use n_slots, n_drifts or sequential_drifts arguments (cant use them together)'
+        # if n_slots is not None:
+        #     assert n_drifts == None and sequential_drifts == False, 'you must use n_slots, n_drifts or sequential_drifts arguments (cant use them together)'
         if n_drifts is not None:
-            assert n_slots == None and sequential_drifts == False, 'you must use n_slots, n_drifts or sequential_drifts arguments (cant use them together)'
+            assert sequential_drifts == False, 'you must use n_drifts or sequential_drifts arguments (cant use them together)'
         if sequential_drifts:
-            assert n_slots == None and n_drifts is None, 'you must use n_slots, n_drifts or sequential_drifts arguments (cant use them together)'
+            assert n_drifts is None, 'you must use n_drifts or sequential_drifts arguments (cant use them together)'
 
         self.n_tasks = n_tasks
-        self.n_slots = n_slots
+        # self.n_slots = n_slots
         self.n_classes = n_classes
         self.random_seed = random_seed
         self.n_drifts = n_drifts
@@ -46,13 +46,14 @@ class StreamSpecification:
         self.max_classes_per_drift = max_classes_per_drift
 
         self._new_classes: list[list[int]] = list()
-        self._drifted_classes: list[list[int]] = list()
+        # Current implementation of task stream does not require having drifted classes separately
+        # self._drifted_classes: list[list[int]] = list()
         if n_drifts is not None:
             self.create_n_drifts()
         elif sequential_drifts:
             self.create_sequential_drifts()
-        else:
-            self.random_class_asigment()
+        # else:
+        #     self.random_class_asigment()
 
         self.current_task = 0
 
@@ -67,72 +68,72 @@ class StreamSpecification:
         drift_begin_idx = 0
         for t in range(self.n_tasks):
             new_classes = list(range(classes_per_task * t, classes_per_task * (t+1)))
-            self._new_classes.append(new_classes)
             if t in drift_indexes:
                 drifted_classes = list(range(drift_begin_idx, classes_per_task * t))
                 drifted_classes = drifted_classes[-min(self.max_classes_per_drift, len(drifted_classes)):]
-                self._drifted_classes.append(drifted_classes)
+                self._new_classes.append(drifted_classes + new_classes)
                 drift_begin_idx = classes_per_task * t
             else:
-                self._drifted_classes.append([])
+                self._new_classes.append(new_classes)
 
     def create_sequential_drifts(self):
         classes_per_task = self.n_classes // self.n_tasks
         assert classes_per_task >= 2, 'At least two classes should be present in each new task'
 
         for t in range(self.n_tasks):
-            self._new_classes.append(list(range(classes_per_task * t, classes_per_task * (t+1))))
-            self._drifted_classes.append(list(range(max(classes_per_task * t - classes_per_task, 0), classes_per_task * t)))
+            new_classes = list(range(classes_per_task * t, classes_per_task * (t + 1)))
+            drifted_classes = list(range(max(classes_per_task * t - classes_per_task, 0), classes_per_task * t))
+            self._new_classes.append(drifted_classes + new_classes)
 
-    def random_class_asigment(self):
-        """ Random class assigment to the tasks.
-        Based on the notion of slot-based generator from https://arxiv.org/pdf/2301.11396
-        Each task has n_slots slots. Each slot can be filled with exatly one class.
-        When classes apears more than once in the stream we assume, that drift occured, and data of given class should change.
-        When there are some classes left at the end, they are appended to the end of the stream.
-        """
-        classes_pool = list(range(self.n_classes))
-        used_classes = set()
-        random_state = np.random.RandomState(self.random_seed)
+    # def random_class_asigment(self):
+    #     """ Random class assigment to the tasks.
+    #     Based on the notion of slot-based generator from https://arxiv.org/pdf/2301.11396
+    #     Each task has n_slots slots. Each slot can be filled with exatly one class.
+    #     When classes apears more than once in the stream we assume, that drift occured, and data of given class should change.
+    #     When there are some classes left at the end, they are appended to the end of the stream.
+    #     """
+    #     classes_pool = list(range(self.n_classes))
+    #     used_classes = set()
+    #     random_state = np.random.RandomState(self.random_seed)
 
-        for _ in range(self.n_tasks):
-            if len(classes_pool) < self.n_slots:
-                classes_pool.extend(range(self.n_classes))
+    #     for _ in range(self.n_tasks):
+    #         if len(classes_pool) < self.n_slots:
+    #             classes_pool.extend(range(self.n_classes))
 
-            task_classes = [None]
-            label = None
-            for _ in range(self.n_slots):
-                while label in task_classes:
-                    label = random_state.choice(classes_pool, replace=False)
-                task_classes.append(label)
-                classes_pool.remove(label)
-                if all(l in set(task_classes) for l in classes_pool):
-                    break
-            task_classes.remove(None)
+    #         task_classes = [None]
+    #         label = None
+    #         for _ in range(self.n_slots):
+    #             while label in task_classes:
+    #                 label = random_state.choice(classes_pool, replace=False)
+    #             task_classes.append(label)
+    #             classes_pool.remove(label)
+    #             if all(l in set(task_classes) for l in classes_pool):
+    #                 break
+    #         task_classes.remove(None)
 
-            self._new_classes.append([])
-            self._drifted_classes.append([])
-            for c in task_classes:
-                if c not in used_classes:
-                    self._new_classes[-1].append(c)
-                    used_classes.add(c)
-                else:
-                    self._drifted_classes[-1].append(c)
+    #         self._new_classes.append([])
+    #         self._drifted_classes.append([])
+    #         for c in task_classes:
+    #             if c not in used_classes:
+    #                 self._new_classes[-1].append(c)
+    #                 used_classes.add(c)
+    #             else:
+    #                 self._drifted_classes[-1].append(c)
 
-        class_mapping = dict()
-        last_class = 0
-        for task_class in self._new_classes:
-            for c in task_class:
-                if c not in class_mapping:
-                    class_mapping[c] = last_class
-                    last_class += 1
+    #     class_mapping = dict()
+    #     last_class = 0
+    #     for task_class in self._new_classes:
+    #         for c in task_class:
+    #             if c not in class_mapping:
+    #                 class_mapping[c] = last_class
+    #                 last_class += 1
 
-        self._new_classes = [sorted(class_mapping[c] for c in task_class) for task_class in self._new_classes]
-        self._drifted_classes = [sorted(class_mapping[c] for c in task_class) for task_class in self._drifted_classes]
+    #     self._new_classes = [sorted(class_mapping[c] for c in task_class) for task_class in self._new_classes]
+    #     self._drifted_classes = [sorted(class_mapping[c] for c in task_class) for task_class in self._drifted_classes]
 
     def __next__(self):
         while self.current_task < self.n_tasks:
-            yield self._new_classes[self.current_task], self._drifted_classes[self.current_task]
+            yield self._new_classes[self.current_task]
             self.current_task += 1
 
     def __iter__(self):

--- a/datasets/utils/continual_dataset.py
+++ b/datasets/utils/continual_dataset.py
@@ -22,7 +22,6 @@ class ContinualDataset:
     SETTING: str
     N_CLASSES_PER_TASK: int
     N_TASKS: int
-    HAS_LABEL_DRIFT: bool = False
 
     def __init__(self, args: Namespace) -> None:
         """
@@ -33,7 +32,8 @@ class ContinualDataset:
         self.test_loaders = []
         self.i = 0
         self.args = args
-        self.drifting_classes = []
+        self.seen_classes = []
+        self.recurring_classes = []
 
         if not all((self.NAME, self.SETTING, self.N_CLASSES_PER_TASK, self.N_TASKS)):
             raise NotImplementedError(
@@ -77,6 +77,12 @@ class ContinualDataset:
 
     def get_drifted_data_loaders(self) -> Tuple[DataLoader, DataLoader]:
         current_classes, drifted_classes = next(self.stream_spec_it)
+        print(f"New Classes: {current_classes}")
+        print(f"Drifted Classes: {drifted_classes}")
+
+        self.seen_classes.extend(current_classes)
+        recurring_classes = list(set(self.seen_classes) & set(drifted_classes))
+        self.recurring_classes = recurring_classes
 
         train_dataset = self.get_dataset(train=True)
         train_dataset.select_classes(current_classes)
@@ -85,39 +91,36 @@ class ContinualDataset:
         test_dataset.select_classes(current_classes)
         test_dataset.prepare_normal_data()
 
-        if len(drifted_classes) > 0:
-            drifting_train_dataset = self.get_dataset(train=True)
-            drifting_train_dataset.select_classes(drifted_classes)
-            drifting_train_dataset.apply_drift(drifted_classes)
-
-            drifting_test_dataset = self.get_dataset(train=False)
-            drifting_test_dataset.select_classes(drifted_classes)
-            drifting_test_dataset.apply_drift(drifted_classes)
-
-            train_dataset = torch.utils.data.ConcatDataset([drifting_train_dataset, train_dataset])
-            test_dataset = torch.utils.data.ConcatDataset([drifting_test_dataset, test_dataset])
         train_loader = DataLoader(train_dataset, batch_size=self.args.batch_size, shuffle=True, num_workers=4)
         self.train_loader = train_loader
+
+        test_loader = DataLoader(test_dataset, batch_size=self.args.batch_size, shuffle=False, num_workers=4)
+        self.test_loaders.append(test_loader)
 
         if len(drifted_classes) > 0:
             for t in range(len(self.test_loaders)):
                 prev_test_data = self.test_loaders[t].dataset
-                if type(prev_test_data) == torch.utils.data.ConcatDataset:
-                    for prev_data in prev_test_data.datasets:
-                        prev_data.apply_drift(drifted_classes)
-                    prev_test_data.cumulative_sizes = prev_test_data.cumsum(prev_test_data.datasets)
-                else:
-                    prev_test_data.apply_drift(drifted_classes)
-                self.test_loaders[t] = DataLoader(prev_test_data, batch_size=self.args.batch_size, shuffle=False, num_workers=4)
-
-        self.drifting_classes = drifted_classes
-
-        test_loader = DataLoader(test_dataset, batch_size=self.args.batch_size, shuffle=False, num_workers=4)
-
-        # current test loader contains undrifted images
-        self.test_loaders.append(test_loader)
+                prev_test_data.apply_drift(drifted_classes)
+                self.test_loaders[t] = DataLoader(prev_test_data, batch_size=self.args.batch_size, 
+                                                  shuffle=False, num_workers=4)
 
         return train_loader, test_loader
+
+    def request_drifted_data_with_current_data(self, drifted_classes) -> DataLoader:
+        drifting_train_dataset = self.get_dataset(train=True)
+        drifting_train_dataset.select_classes(drifted_classes)
+        drifting_train_dataset.apply_drift(drifted_classes)
+        train_dataset = torch.utils.data.ConcatDataset([drifting_train_dataset, self.train_loader.dataset])
+        train_loader = DataLoader(train_dataset, batch_size=self.args.batch_size, shuffle=True, num_workers=4)
+        self.train_loader = train_loader
+        return train_loader
+
+    def request_drifted_data(self, drifted_classes) -> DataLoader:
+        drifting_train_dataset = self.get_dataset(train=True)
+        drifting_train_dataset.select_classes(drifted_classes)
+        drifting_train_dataset.apply_drift(drifted_classes)
+        buffer_resampling_data_loader = DataLoader(drifting_train_dataset, batch_size=self.args.batch_size, shuffle=True, num_workers=4)
+        return buffer_resampling_data_loader
 
     def get_dataset(self, train=True) -> MammothDataset:
         """returns native version of represented dataset"""

--- a/models/der.py
+++ b/models/der.py
@@ -29,7 +29,7 @@ class Der(ContinualModel):
         super(Der, self).__init__(backbone, loss, args, transform)
         self.buffer = Buffer(self.args.buffer_size, self.device, mode=args.buffer_mode)
 
-    def observe(self, inputs, labels, not_aug_inputs, original_targets=None):
+    def observe(self, inputs, labels, not_aug_inputs):
 
         self.opt.zero_grad()
 
@@ -44,6 +44,6 @@ class Der(ContinualModel):
 
         loss.backward()
         self.opt.step()
-        self.buffer.add_data(examples=not_aug_inputs, logits=outputs.data, original_labels=original_targets)
+        self.buffer.add_data(examples=not_aug_inputs, logits=outputs.data)
 
         return loss.item()

--- a/models/der.py
+++ b/models/der.py
@@ -38,12 +38,16 @@ class Der(ContinualModel):
 
         if not self.buffer.is_empty():
             buf_data = self.buffer.get_data(self.args.minibatch_size, transform=self.transform)
-            buf_inputs, buf_logits = buf_data[0], buf_data[1]
+            buf_inputs, buf_logits = buf_data[0], buf_data[2]
             buf_outputs = self.net(buf_inputs)
             loss += self.args.alpha * F.mse_loss(buf_outputs, buf_logits)
 
         loss.backward()
         self.opt.step()
-        self.buffer.add_data(examples=not_aug_inputs, logits=outputs.data)
+        self.buffer.add_data(examples=not_aug_inputs, labels=labels, logits=outputs.data)
 
         return loss.item()
+    
+    def resample(self, inputs, labels, not_aug_inputs):
+        outputs = self.net(inputs)
+        self.buffer.add_data(examples=not_aug_inputs, labels=labels, logits=outputs.data)

--- a/models/derpp.py
+++ b/models/derpp.py
@@ -55,7 +55,23 @@ class Derpp(ContinualModel):
         self.buffer.add_data(examples=not_aug_inputs, labels=labels, logits=outputs.data)
 
         return loss.item()
-    
-    def resample(self, inputs, labels, not_aug_inputs):
-        outputs = self.net(inputs)
-        self.buffer.add_data(examples=not_aug_inputs, labels=labels, logits=outputs.data)
+
+    def buffer_resampling(self, dataset, flagged_classes):
+        for cls in flagged_classes:
+            flushed_indices = self.buffer.flush_class(cls)
+            num_samples_needed = len(flushed_indices)
+            buffer_resampling_data_loader = dataset.request_drifted_data(cls, num_samples_needed)
+
+            data_iter = iter(buffer_resampling_data_loader)
+            inputs, labels, not_aug_inputs = next(data_iter)
+            outputs = self.net(inputs.to(self.device)).data
+            assert inputs.shape[0] == num_samples_needed, f"Requested {num_samples_needed} samples but received {labels.shape[0]}"
+
+            for i, index in enumerate(flushed_indices):
+                self.buffer.num_seen_examples += 1
+                self.buffer.current_size = min(self.buffer.current_size + 1, self.buffer.buffer_size)
+                self.buffer.examples[index] = not_aug_inputs[i].to(self.buffer.device)
+                self.buffer.labels[index] = labels[i].to(self.buffer.device)
+                self.buffer.logits[index] = outputs[i].to(self.buffer.device)
+
+            print(f"Class {cls} samples replaced: {num_samples_needed}")

--- a/models/derpp.py
+++ b/models/derpp.py
@@ -55,3 +55,7 @@ class Derpp(ContinualModel):
         self.buffer.add_data(examples=not_aug_inputs, labels=labels, logits=outputs.data)
 
         return loss.item()
+    
+    def resample(self, inputs, labels, not_aug_inputs):
+        outputs = self.net(inputs)
+        self.buffer.add_data(examples=not_aug_inputs, labels=labels, logits=outputs.data)

--- a/models/derpp.py
+++ b/models/derpp.py
@@ -32,7 +32,7 @@ class Derpp(ContinualModel):
 
         self.buffer = Buffer(self.args.buffer_size, self.device, mode=args.buffer_mode)
 
-    def observe(self, inputs, labels, not_aug_inputs, original_targets=None):
+    def observe(self, inputs, labels, not_aug_inputs):
 
         self.opt.zero_grad()
         outputs = self.net(inputs)
@@ -52,9 +52,6 @@ class Derpp(ContinualModel):
         loss.backward()
         self.opt.step()
 
-        self.buffer.add_data(examples=not_aug_inputs,
-                             labels=labels,
-                             logits=outputs.data,
-                             original_labels=original_targets)
+        self.buffer.add_data(examples=not_aug_inputs, labels=labels, logits=outputs.data)
 
         return loss.item()

--- a/models/er.py
+++ b/models/er.py
@@ -27,7 +27,7 @@ class Er(ContinualModel):
         super(Er, self).__init__(backbone, loss, args, transform)
         self.buffer = Buffer(self.args.buffer_size, self.device, mode=args.buffer_mode)
 
-    def observe(self, inputs, labels, not_aug_inputs, original_targets=None):
+    def observe(self, inputs, labels, not_aug_inputs):
 
         real_batch_size = inputs.shape[0]
 
@@ -43,13 +43,6 @@ class Er(ContinualModel):
         loss.backward()
         self.opt.step()
 
-        if original_targets is not None:
-            original_targets = original_targets[:real_batch_size]
-
-        self.buffer.add_data(
-            examples=not_aug_inputs,
-            labels=labels[:real_batch_size],
-            original_labels=original_targets,
-        )
+        self.buffer.add_data(examples=not_aug_inputs, labels=labels[:real_batch_size])
 
         return loss.item()

--- a/models/er.py
+++ b/models/er.py
@@ -46,3 +46,7 @@ class Er(ContinualModel):
         self.buffer.add_data(examples=not_aug_inputs, labels=labels[:real_batch_size])
 
         return loss.item()
+    
+    def resample(self, inputs, labels, not_aug_inputs):
+        real_batch_size = inputs.shape[0]
+        self.buffer.add_data(examples=not_aug_inputs, labels=labels[:real_batch_size])

--- a/models/er.py
+++ b/models/er.py
@@ -46,7 +46,21 @@ class Er(ContinualModel):
         self.buffer.add_data(examples=not_aug_inputs, labels=labels[:real_batch_size])
 
         return loss.item()
-    
-    def resample(self, inputs, labels, not_aug_inputs):
-        real_batch_size = inputs.shape[0]
-        self.buffer.add_data(examples=not_aug_inputs, labels=labels[:real_batch_size])
+
+    def buffer_resampling(self, dataset, flagged_classes):
+        for cls in flagged_classes:
+            flushed_indices = self.buffer.flush_class(cls)
+            num_samples_needed = len(flushed_indices)
+            buffer_resampling_data_loader = dataset.request_drifted_data(cls, num_samples_needed)
+
+            data_iter = iter(buffer_resampling_data_loader)
+            inputs, labels, not_aug_inputs = next(data_iter)
+            assert inputs.shape[0] == num_samples_needed, f"Requested {num_samples_needed} samples but received {labels.shape[0]}"
+
+            for i, index in enumerate(flushed_indices):
+                self.buffer.num_seen_examples += 1
+                self.buffer.current_size = min(self.buffer.current_size + 1, self.buffer.buffer_size)
+                self.buffer.examples[index] = not_aug_inputs[i].to(self.buffer.device)
+                self.buffer.labels[index] = labels[i].to(self.buffer.device)
+
+            print(f"Class {cls} samples replaced: {num_samples_needed}")

--- a/models/er_ace.py
+++ b/models/er_ace.py
@@ -67,5 +67,20 @@ class ErACE(ContinualModel):
 
         return loss.item()
 
-    def resample(self, inputs, labels, not_aug_inputs):
-        self.buffer.add_data(examples=not_aug_inputs, labels=labels)
+    def buffer_resampling(self, dataset, flagged_classes):
+        for cls in flagged_classes:
+            flushed_indices = self.buffer.flush_class(cls)
+            num_samples_needed = len(flushed_indices)
+            buffer_resampling_data_loader = dataset.request_drifted_data(cls, num_samples_needed)
+
+            data_iter = iter(buffer_resampling_data_loader)
+            inputs, labels, not_aug_inputs = next(data_iter)
+            assert inputs.shape[0] == num_samples_needed, f"Requested {num_samples_needed} samples but received {labels.shape[0]}"
+
+            for i, index in enumerate(flushed_indices):
+                self.buffer.num_seen_examples += 1
+                self.buffer.current_size = min(self.buffer.current_size + 1, self.buffer.buffer_size)
+                self.buffer.examples[index] = not_aug_inputs[i].to(self.buffer.device)
+                self.buffer.labels[index] = labels[i].to(self.buffer.device)
+
+            print(f"Class {cls} samples replaced: {num_samples_needed}")

--- a/models/er_ace.py
+++ b/models/er_ace.py
@@ -66,3 +66,6 @@ class ErACE(ContinualModel):
         self.buffer.add_data(examples=not_aug_inputs, labels=labels)
 
         return loss.item()
+
+    def resample(self, inputs, labels, not_aug_inputs):
+        self.buffer.add_data(examples=not_aug_inputs, labels=labels)

--- a/models/er_ace.py
+++ b/models/er_ace.py
@@ -34,7 +34,7 @@ class ErACE(ContinualModel):
     def end_task(self, dataset):
         self.task += 1
 
-    def observe(self, inputs, labels, not_aug_inputs, original_targets=None):
+    def observe(self, inputs, labels, not_aug_inputs):
 
         present = labels.unique()
         self.seen_so_far = torch.cat([self.seen_so_far, present]).unique()
@@ -63,8 +63,6 @@ class ErACE(ContinualModel):
         loss.backward()
         self.opt.step()
 
-        self.buffer.add_data(examples=not_aug_inputs,
-                             labels=labels,
-                             original_labels=original_targets)
+        self.buffer.add_data(examples=not_aug_inputs, labels=labels)
 
         return loss.item()

--- a/utils/args.py
+++ b/utils/args.py
@@ -63,8 +63,11 @@ def add_management_args(parser: ArgumentParser) -> None:
     parser.add_argument('--notes', type=str, default=None,
                         help='Notes for this run.')
 
-    parser.add_argument('--non_verbose', default=0, choices=[0, 1], type=int, help='Make progress bars non verbose')
+    parser.add_argument('--non_verbose', default=0, choices=[0, 1], type=int, 
+                        help='Make progress bars non verbose')
     parser.add_argument('--disable_log', default=0, choices=[0, 1], type=int, help='Enable csv logging')
+    parser.add_argument("--feature_logging", default=0, choices=[0, 1], type=int,
+                        help="Enable model feature logging after each task")
 
     parser.add_argument('--validation', default=0, choices=[0, 1], type=int,
                         help='Test on the validation set')

--- a/utils/args.py
+++ b/utils/args.py
@@ -45,8 +45,8 @@ def add_experiment_args(parser: ArgumentParser) -> None:
     parser.add_argument('--drift_adaptation', default=0, choices=[0, 1, 2], type=int,
                         help='Choose adaptation method when concept drift is detected: \
                         0 -> No adaptation, 1 -> Full relearning, 2 -> Buffer resampling')
-    parser.add_argument('--n_slots', default=None, type=int, 
-                        help='number of classes per task used when generating task stream randomly based on slots')
+    # parser.add_argument('--n_slots', default=None, type=int, 
+    #                     help='number of classes per task used when generating task stream randomly based on slots')
     parser.add_argument('--n_drifts', default=None, type=int, 
                         help='number of drifts created when creating evenly spaced drfits')
     parser.add_argument('--max_classes_per_drift', type=int, default=0,

--- a/utils/args.py
+++ b/utils/args.py
@@ -36,22 +36,25 @@ def add_experiment_args(parser: ArgumentParser) -> None:
 
     parser.add_argument('--distributed', type=str, default='no', choices=['no', 'dp', 'ddp'])
 
-    parser.add_argument('--train_drift', default=-1, choices=[0, 1, 2, 3, 4, -1], type=int,
-                        help='Choose the drift transform to be applied to training data: \
-                        Defocus Blur-> 0, Gaussian Noise-> 1, Shot Noise-> 2, Speckle Noise-> 3, Identity (No transform) -> 4 or -1')
-    parser.add_argument('--concept_drift', default=1, choices=[0, 1, 2, 3, 4, -1], type=int,
+    parser.add_argument('--concept_drift', default=-1, choices=[-1, 0, 1, 2, 3, 4, 5, 6], type=int,
                         help='Choose the drift transform to be applied to drifting data: \
-                        Defocus Blur-> 0, Gaussian Noise-> 1, Shot Noise-> 2, Speckle Noise-> 3, Identity (No transform) -> 4 or -1')
-
+                        Defocus Blur-> 0, Gaussian Noise-> 1, Shot Noise-> 2, Speckle Noise-> 3, \
+                        Rotation -> 4, Pixel Permutation -> 5, Identity (No transform) -> 6 or -1')
     parser.add_argument('--drift_severity', default=1, choices=[1, 2, 3, 4, 5], type=int,
                         help='Choose the intensity of the drift transform:')
-    parser.add_argument('--buffer_flushing', default=0, choices=[0, 1], type=int,
-                        help='Choose to enable buffer flushing')
-    parser.add_argument('--n_slots', default=None, type=int, help='number of classes per task used when generating task stream randomly based on slots')
-    parser.add_argument('--n_drifts', default=None, type=int, help='number of drifts created when creating evenly spaced drfits')
+    parser.add_argument('--drift_adaptation', default=0, choices=[0, 1, 2], type=int,
+                        help='Choose adaptation method when concept drift is detected: \
+                        0 -> No adaptation, 1 -> Full relearning, 2 -> Buffer resampling')
+    parser.add_argument('--n_slots', default=None, type=int, 
+                        help='number of classes per task used when generating task stream randomly based on slots')
+    parser.add_argument('--n_drifts', default=None, type=int, 
+                        help='number of drifts created when creating evenly spaced drfits')
     parser.add_argument('--max_classes_per_drift', type=int, default=0,
-                        help='maximum number of classes that can be drifted at once. Used only with n_drifts. If set to 0 (default), all previous classes will drift.')
-    parser.add_argument('--sequential_drifts', action='store_true', help='if used each task will consist of both new classes and drifted classes from previous task')
+                        help='maximum number of classes that can be drifted at once. Used only with n_drifts. \
+                        If set to 0 (default), all previous classes will drift.')
+    parser.add_argument('--sequential_drifts', action='store_true', 
+                        help='if used each task will consist of both new classes and \
+                        drifted classes from previous task')
 
 
 def add_management_args(parser: ArgumentParser) -> None:

--- a/utils/buffer.py
+++ b/utils/buffer.py
@@ -122,7 +122,7 @@ class Buffer:
             assert n_tasks is not None
             self.task_number = n_tasks
             self.buffer_portion_size = buffer_size // n_tasks
-        self.attributes = ['examples', 'labels', 'logits', 'task_labels', 'original_labels']
+        self.attributes = ['examples', 'labels', 'logits', 'task_labels']
 
     def to(self, device):
         self.device = device
@@ -135,7 +135,7 @@ class Buffer:
         return min(self.num_seen_examples, self.current_size, self.buffer_size)
 
     def init_tensors(self, examples: torch.Tensor, labels: torch.Tensor,
-                     logits: torch.Tensor, task_labels: torch.Tensor, original_labels: torch.Tensor) -> None:
+                     logits: torch.Tensor, task_labels: torch.Tensor) -> None:
         """
         Initializes just the required tensors.
         :param examples: tensor containing the images
@@ -149,7 +149,7 @@ class Buffer:
                 typ = torch.int64 if attr_str.endswith('els') else torch.float32
                 setattr(self, attr_str, torch.full((self.buffer_size, *attr.shape[1:]), fill_value=-1, dtype=typ, device=self.device))
 
-    def add_data(self, examples, labels=None, logits=None, task_labels=None, original_labels=None):
+    def add_data(self, examples, labels=None, logits=None, task_labels=None):
         """
         Adds the data to the memory buffer according to the reservoir strategy.
         :param examples: tensor containing the images
@@ -159,7 +159,7 @@ class Buffer:
         :return:
         """
         if not hasattr(self, 'examples'):
-            self.init_tensors(examples, labels, logits, task_labels, original_labels)
+            self.init_tensors(examples, labels, logits, task_labels)
 
         for i in range(examples.shape[0]):
             if self.mode == 'reservoir' or self.mode == 'ring':
@@ -178,8 +178,6 @@ class Buffer:
                     self.logits[index] = logits[i].to(self.device)
                 if task_labels is not None:
                     self.task_labels[index] = task_labels[i].to(self.device)
-                if original_labels is not None:
-                    self.original_labels[index] = original_labels[i].to(self.device)
 
     def get_data(self, size: int, transform: nn.Module = None, return_index=False) -> Tuple:
         """
@@ -258,17 +256,14 @@ class Buffer:
         self.num_seen_examples = 0
         self.current_size = 0
 
-    def get_class_data(self, label: int, labeldrift: bool = False) -> torch.Tensor:
+    def get_class_data(self, label: int) -> torch.Tensor:
         """
         Return all samples with given label.
         If label not present in the buffer, then raise ValueError exception.
         """
-        if labeldrift:
-            idx = torch.argwhere(self.original_labels == label).flatten()
-        else:
-            idx = torch.argwhere(self.labels == label).flatten()
+        idx = torch.argwhere(self.labels == label).flatten()
         if len(idx) == 0:
-            print(f'{"Metaclass" if labeldrift else "Class"} label {label} not present in the buffer')
+            print(f'Class label {label} not present in the buffer')
             return 0
         class_samples = self.examples[idx]
         return class_samples
@@ -283,19 +278,15 @@ class Buffer:
         else:
             return 0
 
-    def flush_class(self, label: int, labeldrift: bool = False) -> None:
+    def flush_class(self, label: int) -> None:
         """
         Removes all samples with given label.
         If label not present in the buffer, then raise ValueError exception.
         """
-        if labeldrift:
-            idx = torch.argwhere(self.original_labels != label).flatten()
-            num_removed = len(self.original_labels) - len(idx)
-        else:
-            idx = torch.argwhere(self.labels != label).flatten()
-            num_removed = len(self.labels) - len(idx)
+        idx = torch.argwhere(self.labels != label).flatten()
+        num_removed = len(self.labels) - len(idx)
         if num_removed == 0:
-            raise ValueError(f'{"Metaclass" if labeldrift else "Class"} label {label} not present in the buffer')
+            raise ValueError(f'Class label {label} not present in the buffer')
         for attr_str in self.attributes:
             if hasattr(self, attr_str):
                 tensor = getattr(self, attr_str)
@@ -306,4 +297,4 @@ class Buffer:
                 setattr(self, attr_str, new_tensor)
         self.current_size = max(self.current_size - num_removed, 0)
         self.num_seen_examples -= num_removed
-        print(f'{"Metaclass" if labeldrift else "Class"} {label} samples removed: {num_removed}')
+        print(f'Class {label} samples removed: {num_removed}')

--- a/utils/drift_detection.py
+++ b/utils/drift_detection.py
@@ -4,64 +4,7 @@ import torch.nn as nn
 import torchvision.models as models
 from torchvision.models import ResNet18_Weights
 from functools import partial
-from alibi_detect.cd.pytorch import preprocess_drift
-from alibi_detect.cd import MMDDrift, ClassifierUncertaintyDrift
-
-
-def initialize_detector(ref_data, device):
-    encoding_dim = 32
-    encoder_net = (
-        nn.Sequential(
-            nn.Conv2d(3, 64, 4, stride=2, padding=0),
-            nn.ReLU(),
-            nn.Conv2d(64, 128, 4, stride=2, padding=0),
-            nn.ReLU(),
-            nn.Conv2d(128, 512, 4, stride=2, padding=0),
-            nn.ReLU(),
-            nn.Flatten(),
-            nn.Linear(2048, encoding_dim),
-        )
-        .to(device)
-        .eval()
-    )
-
-    preprocess_fn = partial(
-        preprocess_drift, model=encoder_net, device=device, batch_size=512
-    )
-    cd = MMDDrift(
-        ref_data,
-        backend="pytorch",
-        p_val=0.05,
-        preprocess_fn=preprocess_fn,
-        n_permutations=100,
-    )
-
-    return cd
-
-
-def detect_drift(drifting_classes, train_loader, model):
-    if len(drifting_classes) == 0:
-        return
-
-    labels = ["No!", "Yes!"]
-
-    for cls in drifting_classes:
-        filtered_images = []
-        for img_batch, target_batch, _ in train_loader:
-            mask = target_batch == cls
-            selected_images = img_batch[mask]
-            filtered_images.append(selected_images)
-
-        new_images = torch.cat(filtered_images, dim=0)
-
-        if new_images.size(0) > 0:
-            ref_samples = model.buffer.get_class_data(cls)
-            drift_detector = initialize_detector(ref_samples, model.device)
-            preds = drift_detector.predict(new_images)
-            print("")
-            print(f"Drift in class {cls}? {labels[preds['data']['is_drift']]}")
-            print(f'p-value: {preds["data"]["p_val"]:.3f}')
-            print(f'MMD-Distance: {preds["data"]["distance"]:.3f}')
+from alibi_detect.cd import ClassifierUncertaintyDrift
 
 
 def initialize_uncertainty_detector(ref_data, device):
@@ -72,35 +15,31 @@ def initialize_uncertainty_detector(ref_data, device):
     num_features = clf.fc.in_features
     clf.fc = nn.Linear(num_features, encoding_dim)
     clf = clf.to(device).eval()
-    cd = ClassifierUncertaintyDrift(
-        ref_data, model=clf, backend="pytorch", p_val=0.05, preds_type="logits"
-    )
+    cd = ClassifierUncertaintyDrift(ref_data, model=clf, backend="pytorch", p_val=0.05, preds_type="logits")
 
     return cd
 
 
-def detect_uncertainty_drift(dataset, train_loader, model):
-    drifting_classes = dataset.drifting_classes
-    if len(drifting_classes) == 0:
-        return
+def detect_uncertainty_drift(dataset, model) -> list:
+    recurring_classes = dataset.recurring_classes
+    if len(recurring_classes) == 0:
+        return []
 
     labels = ["No!", "Yes!"]
+    flagged_classes = []
 
-    for cls in drifting_classes:
+    for cls in recurring_classes:
         filtered_images = []
-        for batch in train_loader:
-            img_batch, target_batch = batch[0], batch[1]
-            mask = target_batch == cls
-            if dataset.HAS_LABEL_DRIFT:
-                original_target_batch = batch[-1]
-                mask = original_target_batch == cls
-            selected_images = img_batch[mask]
-            filtered_images.append(selected_images)
+        for test_loader in dataset.test_loaders:
+            for batch in test_loader:
+                img_batch, target_batch = batch[0], batch[1]
+                mask = target_batch == cls
+                selected_images = img_batch[mask]
+                filtered_images.append(selected_images)
 
         new_images = torch.cat(filtered_images, dim=0)
-
         if new_images.size(0) > 0 and hasattr(model, "buffer"):
-            ref_samples = model.buffer.get_class_data(cls, labeldrift=dataset.HAS_LABEL_DRIFT)
+            ref_samples = model.buffer.get_class_data(cls)
             if not isinstance(ref_samples, int):
                 drift_detector = initialize_uncertainty_detector(ref_samples, model.device)
                 preds = drift_detector.predict(new_images)
@@ -108,4 +47,7 @@ def detect_uncertainty_drift(dataset, train_loader, model):
                 print(f"Feature-wise p-values: {', '.join([f'{p_val:.3f}' for p_val in preds['data']['p_val']])}")
 
                 if preds["data"]["is_drift"]:  # removing drifted samples from buffer
-                    model.buffer.flush_class(cls, labeldrift=dataset.HAS_LABEL_DRIFT)
+                    model.buffer.flush_class(cls)
+                    flagged_classes.append(cls)
+
+    return flagged_classes

--- a/utils/drift_detection.py
+++ b/utils/drift_detection.py
@@ -46,8 +46,7 @@ def detect_uncertainty_drift(dataset, model) -> list:
                 print(f"Drift in class {cls}? {labels[preds['data']['is_drift']]}")
                 print(f"Feature-wise p-values: {', '.join([f'{p_val:.3f}' for p_val in preds['data']['p_val']])}")
 
-                if preds["data"]["is_drift"]:  # removing drifted samples from buffer
-                    model.buffer.flush_class(cls)
+                if preds["data"]["is_drift"]:
                     flagged_classes.append(cls)
 
     return flagged_classes

--- a/utils/feature_shift_logging.py
+++ b/utils/feature_shift_logging.py
@@ -1,0 +1,30 @@
+import torch
+
+
+def extract_features(model, dataloader, file_path):
+
+    status = model.net.training
+    model.net.eval()
+
+    features_list = []
+    labels_list = []
+
+    with torch.no_grad():
+        for data in dataloader:
+            inputs, labels = data[0], data[1]
+            inputs = inputs.to(model.device)
+            features = model.net(inputs, returnt="features")
+            features_list.append(features.cpu())
+            labels_list.append(labels)
+
+    features = torch.cat(features_list)
+    labels = torch.cat(labels_list)
+
+    print("Extracted Features Shape: ", features.shape)
+    print("Labels Shape: ", labels.shape)
+
+    torch.save({"features": features, "labels": labels}, file_path)
+    print("Features saved successfully")
+
+    model.net.train(status)
+    return

--- a/utils/training.py
+++ b/utils/training.py
@@ -162,8 +162,7 @@ def train(model: ContinualModel, dataset: ContinualDataset, args: Namespace) -> 
                         inputs = inputs.to(model.device)
                         labels = labels.to(model.device)
                         not_aug_inputs = not_aug_inputs.to(model.device)
-                        real_batch_size = inputs.shape[0]
-                        model.buffer.add_data(examples=not_aug_inputs, labels=labels[:real_batch_size])
+                        model.resample(inputs, labels, not_aug_inputs)
 
         # unique_labels = get_unique_labels(train_loader)
         # print("Unique labels in train loader:", unique_labels)
@@ -219,7 +218,7 @@ def train(model: ContinualModel, dataset: ContinualDataset, args: Namespace) -> 
 
     log_filename = (
         f"../results/Concept-Drift/{datetime.now().strftime('%m-%d-%y-%H-%M-%S')}-{args.dataset}-{args.model}-buf-{args.buffer_size}"
-        f"{'-drift-' + str(args.concept_drift) + '-n-' + str(args.n_drifts) + '-severity-' + str(args.drift_severity) + '-adaptation-' + str(args.drift_adaptation) + '-cpd-' + str(args.max_classes_per_drift) if args.concept_drift > -1 else '-no-drift'}.json"
+        f"{'-drift-' + str(args.concept_drift) + '-n-' + str(args.n_drifts) + '-adaptation-' + str(args.drift_adaptation) if args.concept_drift > -1 else '-no-drift'}.json"
     )
 
     with open(log_filename, 'w') as jsonfile:

--- a/utils/training.py
+++ b/utils/training.py
@@ -66,7 +66,7 @@ def evaluate(model: ContinualModel, dataset: ContinualDataset, last=False) -> Tu
         all_labels = list()
 
         # unique_labels = get_unique_labels(test_loader)
-        # print("Unique labels in the data loader:", unique_labels)
+        # print("Unique labels in test loader:", unique_labels)
 
         for data in test_loader:
             with torch.no_grad():
@@ -164,6 +164,9 @@ def train(model: ContinualModel, dataset: ContinualDataset, args: Namespace) -> 
                         not_aug_inputs = not_aug_inputs.to(model.device)
                         real_batch_size = inputs.shape[0]
                         model.buffer.add_data(examples=not_aug_inputs, labels=labels[:real_batch_size])
+
+        # unique_labels = get_unique_labels(train_loader)
+        # print("Unique labels in train loader:", unique_labels)
 
         scheduler = dataset.get_scheduler(model, args)
         for epoch in range(model.args.n_epochs):


### PR DESCRIPTION
The stream specification now generates only a unified list of new and drifted classes. The task stream is capable of identifying new vs. recurring classes and adapting to them as necessary if drift is detected. The n_slots functionality is commented out for now. Only n_drifts and sequentials_drifts are to be used for current experiments. Two new transforms have been added to CIFAR datasets to simulate proper domain shifts. The continual dataset pipeline changed to introduce drift during testing instead of training. Two drift adaptation methods have been implemented when drift is detected (full relearning and buffer resampling). Drift detection now works on the test loader instead of the train loader. Drift detection is fully functional for permutation drift. Label drift approaches have been removed because drift can be achieved solely through image permutation transform. Some arguments and log file naming conventions have been changed.